### PR TITLE
Detect commands in issues and pull requests body

### DIFF
--- a/src/tmpl.rs
+++ b/src/tmpl.rs
@@ -1,6 +1,6 @@
 use crate::{
-    github::{IssueCommentEvent, TeamSlug, UserName},
-    votes::{CfgProfile, VoteResults},
+    github::{TeamSlug, UserName},
+    votes::{CfgProfile, CreateVoteInput, VoteResults},
 };
 use askama::Template;
 
@@ -63,7 +63,7 @@ pub(crate) struct VoteCreated<'a> {
 
 impl<'a> VoteCreated<'a> {
     /// Create a new VoteCreated template.
-    pub(crate) fn new(event: &'a IssueCommentEvent, cfg: &'a CfgProfile) -> Self {
+    pub(crate) fn new(input: &'a CreateVoteInput, cfg: &'a CfgProfile) -> Self {
         // Prepare teams and users allowed to vote
         let (mut teams, mut users) = (vec![], vec![]);
         if let Some(allowed_voters) = &cfg.allowed_voters {
@@ -76,15 +76,15 @@ impl<'a> VoteCreated<'a> {
         }
 
         // Get organization name if available
-        let org = match &event.organization {
-            Some(org) => org.login.as_ref(),
+        let org = match &input.organization {
+            Some(org) => org.as_ref(),
             None => "",
         };
 
         Self {
-            creator: &event.comment.user.login,
-            issue_title: &event.issue.title,
-            issue_number: event.issue.number,
+            creator: &input.created_by,
+            issue_title: &input.issue_title,
+            issue_number: input.issue_number,
             duration: humantime::format_duration(cfg.duration).to_string(),
             pass_threshold: cfg.pass_threshold,
             org,


### PR DESCRIPTION
Before, it was necessary to add an extra comment with the `/vote` command to create a vote, as we were only processing comments events (in both issues and pull requests).

This PR adds the ability to also handle events for opened issues and pull requests, processing the corresponding entity body to detect commands. So it's possible now to launch a vote directly on the issue or pull request body without requiring an extra comment.

Closes #5

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>