### PR TITLE
Add link to GitVote app to artifact hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-The first step is to install the **GitVote** application in the organization or repositories you'd like.
+The first step is to install the [**GitVote**](https://artifacthub.io/packages/helm/gitvote/gitvote) application in the organization or repositories you'd like.
 
 Once the application has been installed we can proceed with its configuration.
 


### PR DESCRIPTION
The badge in the Readme does have the link to the GitVote artifact hub location but having a link in the usage section in the readme indicates that it is the place where we should install/setup GitVote from. 

Initially I spent time browsing the github marketplace for the GitVote app but as soon as I was pointed to the artifacthub location it was easy to figure out what to do. 

If the maintainers prefer a better way, I'm happy to modify or close this PR. 
