### PR TITLE
Display how many folks are against the vote as well

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -103,6 +103,7 @@ pub(crate) struct VoteResults {
     pub pass_threshold: f64,
     pub in_favor: i64,
     pub against: i64,
+    pub against_percentage: f64,
     pub abstain: i64,
     pub not_voted: i64,
     pub binding: i64,
@@ -184,8 +185,10 @@ pub(crate) async fn calculate<'a>(
         }
     }
     let mut in_favor_percentage = 0.0;
+    let mut against_percentage = 0.0;
     if !allowed_voters.is_empty() {
         in_favor_percentage = in_favor as f64 / allowed_voters.len() as f64 * 100.0;
+        against_percentage = against as f64 / allowed_voters.len() as f64 * 100.0;
     }
     let pending_voters: Vec<UserName> =
         allowed_voters.iter().filter(|user| !votes.contains_key(*user)).cloned().collect();
@@ -196,6 +199,7 @@ pub(crate) async fn calculate<'a>(
         pass_threshold: vote.cfg.pass_threshold,
         in_favor,
         against,
+        against_percentage,
         abstain,
         not_voted: pending_voters.len() as i64,
         binding,
@@ -321,6 +325,7 @@ mod tests {
                 pass_threshold: 50.0,
                 in_favor: 0,
                 against: 1,
+                against_percentage: 100.0,
                 abstain: 0,
                 not_voted: 0,
                 binding: 1,
@@ -368,6 +373,7 @@ mod tests {
                 pass_threshold: 50.0,
                 in_favor: 0,
                 against: 0,
+                against_percentage: 0.0,
                 abstain: 0,
                 not_voted: 1,
                 binding: 0,
@@ -419,6 +425,7 @@ mod tests {
                 pass_threshold: 50.0,
                 in_favor: 1,
                 against: 1,
+                against_percentage: 25.0,
                 abstain: 1,
                 not_voted: 1,
                 binding: 3,
@@ -498,6 +505,7 @@ mod tests {
                 pass_threshold: 75.0,
                 in_favor: 3,
                 against: 0,
+                against_percentage: 0.0,
                 abstain: 0,
                 not_voted: 1,
                 binding: 3,

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -157,6 +157,7 @@ pub(crate) fn setup_test_vote_results() -> VoteResults {
         pass_threshold: 50.0,
         in_favor: 1,
         against: 0,
+        against_percentage: 0.0,
         abstain: 0,
         not_voted: 0,
         binding: 1,

--- a/templates/vote-closed.md
+++ b/templates/vote-closed.md
@@ -4,8 +4,7 @@
 
 The vote {% if results.passed %}**passed**! 🎉{% else %}**did not pass**.{% endif %}
 
-`{{ "{:.2}"|format(results.in_favor_percentage) }}%` of the users with binding vote were in favor (passing threshold: `{{ results.pass_threshold }}%`).
-
+`{{ "{:.2}"|format(results.in_favor_percentage) }}%` of the users with binding vote were in favor and `{{ "{:.2}"|format(results.against_percentage) }}%` were against (passing threshold: `{{ results.pass_threshold }}%`).
 ### Summary
 
 |        In favor        |        Against        |       Abstain        |        Not voted        |

--- a/templates/vote-status.md
+++ b/templates/vote-status.md
@@ -1,6 +1,6 @@
 ## Vote status
 
-So far `{{ "{:.2}"|format(results.in_favor_percentage) }}%` of the users with binding vote are in favor (passing threshold: `{{ results.pass_threshold }}%`).
+So far `{{ "{:.2}"|format(results.in_favor_percentage) }}%` of the users with binding vote are in favor and `{{ "{:.2}"|format(results.against_percentage) }}%` are against (passing threshold: `{{ results.pass_threshold }}%`).
 
 ### Summary
 


### PR DESCRIPTION
We were wondering about the results of a gitvote ... The vote status is missing a big piece of context even though there is a table below it.

![image](https://github.com/user-attachments/assets/7c0747f0-29aa-4ed7-b4eb-ca2418308a36)
